### PR TITLE
[サンプル] ディレクトリインストール時に、記事削除で初期ページにもどらない不具合修正

### DIFF
--- a/app/PluginsOption/User/Samples/SamplesPlugin.php
+++ b/app/PluginsOption/User/Samples/SamplesPlugin.php
@@ -42,7 +42,6 @@ class SamplesPlugin extends UserPluginOptionBase
     {
         // 標準関数以外で画面などから呼ばれる関数の定義
         $functions = array();
-        $functions['get']  = ['index'];
         return $functions;
     }
 
@@ -73,7 +72,7 @@ class SamplesPlugin extends UserPluginOptionBase
     {
         if (is_null($action)) {
             // プラグイン内からの呼び出しを想定。処理を通す。
-        } elseif (in_array($action, ['index', 'save', 'delete'])) {
+        } elseif (in_array($action, ['save', 'delete'])) {
             // コアから呼び出し。posts.update|posts.deleteの権限チェックを指定したアクションは、処理を通す。
         } else {
             // それ以外のアクションは null で返す。
@@ -211,8 +210,8 @@ class SamplesPlugin extends UserPluginOptionBase
         }
         session()->flash("flash_message_for_frame{$frame_id}", $message);
 
-        // 登録後はリダイレクトして編集ページを開く。
-        return new Collection(['redirect_path' => url('/') . "/plugin/samples/index/" . $page_id . "/" . $frame_id . "/" . $post->id . "#frame-" . $frame_id]);
+        // リダイレクトして初期表示ページを開く。
+        return new Collection(['redirect_path' => url($this->page->permanent_link) . "#frame-{$frame_id}" ]);
     }
 
     /**
@@ -248,8 +247,7 @@ class SamplesPlugin extends UserPluginOptionBase
 
         session()->flash("flash_message_for_frame{$frame_id}", '削除しました。');
 
-        // 削除後はリダイレクトして一覧ページを開く。
-        return new Collection(['redirect_path' => url('/') . "/plugin/samples/index/" . $page_id . "/" . $frame_id . "#frame-" . $frame_id]);
+        // リダイレクト先を指定しないため、画面から渡されたredirect_pathに飛ぶ
     }
 
     /**

--- a/resources/views/plugins_option/user/samples/default/edit.blade.php
+++ b/resources/views/plugins_option/user/samples/default/edit.blade.php
@@ -76,7 +76,7 @@
                 {{-- 削除ボタン --}}
                 <form action="{{url('/')}}/redirect/plugin/samples/delete/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame->id}}" method="POST">
                     {{csrf_field()}}
-                    <input type="hidden" name="redirect_path" value="{{$page->permanent_link}}#frame-{{$frame_id}}">
+                    <input type="hidden" name="redirect_path" value="{{url($page->permanent_link)}}#frame-{{$frame_id}}">
                     <button type="submit" class="btn btn-danger" onclick="javascript:return confirm('データを削除します。\nよろしいですか？')">
                         <i class="fas fa-check"></i> 本当に削除する
                     </button>


### PR DESCRIPTION
# 修正内容

* [bugfix: サンプル, ディレクトリインストール時に、記事削除で初期ページにもどらない不具合修正](https://github.com/opensource-workshop/connect-cms_option/pull/21/commits/fa84ef54cf294551a0ab8ebf48c8757135c32bfc)
* [refactor: サンプル, 登録後・削除後は初期表示ページに飛ぶ処理の書き方見直し](https://github.com/opensource-workshop/connect-cms_option/pull/21/commits/0c0d8f212505f7ad2ca199bb9b967e569436b9ed)

# 関連

* https://github.com/opensource-workshop/connect-cms_option/pull/20